### PR TITLE
add tc_13_01_06_check_info_block_text_in_section1

### DIFF
--- a/locators/main_page_locators.py
+++ b/locators/main_page_locators.py
@@ -23,6 +23,7 @@ class MainPageLocators:
     # Promo Block
     PROMO_BLOCK = (By.CSS_SELECTOR, ".blocks-promo")
     SECTION_1_IMAGE = (By.CSS_SELECTOR, '.home-main img')
+    SECTION_1_INFO_BLOCK_TEXT = (By.CSS_SELECTOR, '.home-main .info')
     SECTION_2_BLOCK_1 = (By.CSS_SELECTOR, '.home-pants')
     SECTION_2_BLOCK_1_IMAGE = (By.CSS_SELECTOR, ".home-pants img")
     SECTION_2_BLOCK_1_INFO_BLOCK = (By.CSS_SELECTOR, ".home-pants .content")

--- a/pages/main_page.py
+++ b/pages/main_page.py
@@ -120,6 +120,12 @@ class PromoBlock(BasePage):
         section1_image = element.get_attribute("src")
         return section1_image
 
+    def check_info_block_text_in_section1(self):
+        """Checks the text of info-block in section 1 'home-main'"""
+        element = self.element_is_visible(self.locators.SECTION_1_INFO_BLOCK_TEXT)
+        info_block_text = element.text
+        return info_block_text
+
     def check_section2_block1_display(self):
         """Checks section 2 block 1 'home-pants' display"""
         section2_block1 = self.element_is_visible(self.locators.SECTION_2_BLOCK_1)

--- a/tests/test_main_page.py
+++ b/tests/test_main_page.py
@@ -99,6 +99,14 @@ class TestMainPage:
             section1_image = page.check_image_in_section1()
             assert section1_image == ImageUrls.SECTION_1_IMAGE_URL, "The image is not correct"
 
+        def test_tc_13_01_06_check_info_block_text_in_section1(self, driver):
+            """This test checks if the info block text in section 1 'home-main' is correct
+            in the Promo Block under header on the main page"""
+            page = PromoBlock(driver, MAIN_PAGE_URL)
+            page.open()
+            info_block_text = page.check_info_block_text_in_section1()
+            assert info_block_text == "New Luma Yoga Collection", "The text is not correct"
+
         def test_tc_13_01_10_check_section2_block1_display(self, driver):
             """This test checks if block 1 'home-pants' is displayed in section 2
             of Promo Block under header on the main page"""


### PR DESCRIPTION
This test checks if the info block text in section 1 'home-main' is correct in the Promo Block under header on the main page